### PR TITLE
add pydantic + strawberry input poc

### DIFF
--- a/backend/apps/owasp/api/internal/mutations/board_candidate_claim.py
+++ b/backend/apps/owasp/api/internal/mutations/board_candidate_claim.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import pydantic
 import strawberry
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -21,13 +22,27 @@ CLAIM_NOT_FOUND_MSG = "Claim not found."
 GENERIC_ERROR_MSG = "Something went wrong."
 
 
-@strawberry.input
+class CreateClaimPydanticInput(pydantic.BaseModel):
+    """Pydantic Model for creating a claim."""
+
+    description: str = pydantic.Field(min_length=10, max_length=100)
+    name: str = pydantic.Field(min_length=5, max_length=50)
+    year: int
+
+    @pydantic.field_validator("year")
+    @classmethod
+    def validate_year_not_future(cls, value: int) -> int:
+        """Validate year."""
+        max_val = 2027
+        if value > max_val:
+            msg = "example error"
+            raise ValueError(msg)
+        return value
+
+
+@strawberry.experimental.pydantic.input(model=CreateClaimPydanticInput, all_fields=True)
 class CreateClaimInput:
     """Input for creating a claim."""
-
-    description: str
-    name: str
-    year: int
 
 
 @strawberry.input
@@ -141,10 +156,9 @@ class BoardCandidateClaimMutations:
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     @transaction.atomic
-    def create_board_candidate_claim(
-        self, info: Info, input_data: CreateClaimInput
-    ) -> ClaimResult:
+    def create_board_candidate_claim(self, info: Info, data: CreateClaimInput) -> ClaimResult:
         """Create a new draft claim for a candidate."""
+        input_data = data.to_pydantic()
         user = info.context.request.user
         if user.github_user is None:
             return ClaimResult(ok=False, code="FORBIDDEN", message=ACCESS_DENIED_MSG)


### PR DESCRIPTION
Resolves #657 

I think the error message can be improved by catching the exception.

Docs: https://strawberry.rocks/docs/integrations/pydantic
This is an experimental feature, there's a discussion related to this: https://github.com/strawberry-graphql/strawberry/issues/2181

Screenshot:
<img width="1261" height="645" alt="image" src="https://github.com/user-attachments/assets/21fe278c-93d0-41c0-9a7e-b8d3334bf905" />



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/rudransh-shrivastava/Nest/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

